### PR TITLE
Add nix build support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1688466019,
+        "narHash": "sha256-VeM2akYrBYMsb4W/MmBo1zmaMfgbL4cH3Pu8PGyIwJ0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "8e8d955c22df93dbe24f19ea04f47a74adbdc5ec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1690720142,
+        "narHash": "sha256-GywuiZjBKfFkntQwpNQfL+Ksa2iGjPprBGL0/psgRZM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3acb5c4264c490e7714d503c7166a3fde0c51324",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,22 +1,77 @@
 {
   "nodes": {
-    "flake-parts": {
+    "crane": {
       "inputs": {
-        "nixpkgs-lib": [
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1688466019,
-        "narHash": "sha256-VeM2akYrBYMsb4W/MmBo1zmaMfgbL4cH3Pu8PGyIwJ0=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "8e8d955c22df93dbe24f19ea04f47a74adbdc5ec",
+        "lastModified": 1688772518,
+        "narHash": "sha256-ol7gZxwvgLnxNSZwFTDJJ49xVY5teaSvF7lzlo3YQfM=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "8b08e96c9af8c6e3a2b69af5a7fa168750fcf88e",
         "type": "github"
       },
       "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1687709756,
+        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     },
@@ -38,8 +93,64 @@
     },
     "root": {
       "inputs": {
-        "flake-parts": "flake-parts",
+        "crane": "crane",
+        "flake-utils": "flake-utils_2",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "crane",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "crane",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1688351637,
+        "narHash": "sha256-CLTufJ29VxNOIZ8UTg0lepsn3X03AmopmaLTTeHDCL4=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "f9b92316727af9e6c7fee4a761242f7f46880329",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,60 @@
+{
+  description = "Basic formatter for the Typst language with a future!";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
+  };
+
+  outputs = inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [ "x86_64-linux" ];
+
+      perSystem =
+        { config
+        , pkgs
+        , system
+        , ...
+        }: {
+          devShells.default = pkgs.mkShell {
+            inputsFrom = [ config.packages.typstfmt ];
+            packages = with pkgs; [
+              cargo
+              clippy
+              pre-commit
+              rust-analyzer
+              rustc
+              rustfmt
+              rustPackages.clippy
+            ];
+
+            RUST_SRC_PATH = pkgs.rustPlatform.rustLibSrc;
+          };
+
+          packages =
+            {
+              typstfmt = pkgs.rustPlatform.buildRustPackage {
+                name = "typstfmt";
+
+                src = ./.;
+
+                cargoLock = {
+                  lockFile = ./Cargo.lock;
+                  outputHashes."typst-syntax-0.6.0" = "sha256-oAn783W7P8zY8gqPyy/w1goW/tdLJgf0qm2qAEJ9Vto=";
+                };
+
+                nativeBuildInputs = with pkgs; [ pkg-config cargo-insta ];
+
+                hash = "sha256-oAn783W7P8zY8gqPyy/w1goW/tdLJgf0qm2qAEJ9Vto=";
+              };
+            }
+            // { default = config.packages.typstfmt; };
+
+          formatter = pkgs.alejandra;
+        };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -4,57 +4,50 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
-    flake-parts = {
-      url = "github:hercules-ci/flake-parts";
-      inputs.nixpkgs-lib.follows = "nixpkgs";
+    crane = {
+      url = "github:ipetkov/crane";
+      inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = inputs:
-    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
-      systems = [ "x86_64-linux" ];
-
-      perSystem =
-        { config
-        , pkgs
-        , system
-        , ...
-        }: {
-          devShells.default = pkgs.mkShell {
-            inputsFrom = [ config.packages.typstfmt ];
-            packages = with pkgs; [
-              cargo
-              clippy
-              pre-commit
-              rust-analyzer
-              rustc
-              rustfmt
-              rustPackages.clippy
-            ];
-
-            RUST_SRC_PATH = pkgs.rustPlatform.rustLibSrc;
-          };
-
-          packages =
-            {
-              typstfmt = pkgs.rustPlatform.buildRustPackage {
-                name = "typstfmt";
-
-                src = ./.;
-
-                cargoLock = {
-                  lockFile = ./Cargo.lock;
-                  outputHashes."typst-syntax-0.6.0" = "sha256-oAn783W7P8zY8gqPyy/w1goW/tdLJgf0qm2qAEJ9Vto=";
-                };
-
-                nativeBuildInputs = with pkgs; [ pkg-config cargo-insta ];
-
-                hash = "sha256-oAn783W7P8zY8gqPyy/w1goW/tdLJgf0qm2qAEJ9Vto=";
-              };
-            }
-            // { default = config.packages.typstfmt; };
-
-          formatter = pkgs.alejandra;
+  outputs = { self, nixpkgs, crane, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
         };
-    };
+
+        craneLib = crane.lib.${system};
+        typstfmt =
+          craneLib.buildPackage
+            {
+              src = craneLib.path ./.;
+
+              buildInputs = [
+                pkgs.cargo-insta
+              ];
+            };
+      in
+      {
+        checks = {
+          inherit typstfmt;
+        };
+
+        packages.default = typstfmt;
+
+        apps.default = flake-utils.lib.mkApp {
+          drv = typstfmt;
+        };
+
+        devShells.default = pkgs.mkShell {
+          inputsFrom = builtins.attrValues self.checks.${system};
+
+          nativeBuildInputs = with pkgs; [
+            cargo
+            rustc
+          ];
+        };
+      });
 }


### PR DESCRIPTION
This commit adds support for the nix build system in the form of a flake. This allows any contributor to be able to build the project in a reproducible manner, but more importantly allows other nix flakes to use this project as an input.