### PR TITLE
symlink README.md to lib

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc = include_str!("../../README.md")]
+#![doc = include_str!("../README.md")]
 #![warn(clippy::all)]
 
 use itertools::Itertools;


### PR DESCRIPTION
this allows the lib to be vendored as a crate, otherwise it would depend on files outside the crate.