### PR TITLE
fix: Str literal in code/math mode to be preserved

### DIFF
--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -79,6 +79,7 @@ fn visit(node: &LinkedNode, ctx: &mut Ctx) -> String {
         }
         Equation => math::format_equation(node, &res, ctx),
         Math => math::format_math(node, &res, ctx),
+        Str => no_format(node, &res, ctx),
         _ => format_default(node, &res, ctx),
     };
     if node.children().count() == 0 {

--- a/lib/src/tests/snippets.rs
+++ b/lib/src/tests/snippets.rs
@@ -35,6 +35,8 @@ make_test!(official, OFFICIAL);
 make_test!(raw_text, RAW);
 make_test!(tabs, TABS);
 make_test!(on_off, ON_OFF);
+test_eq!(string_literal_in_math_mode, r#"$ a "        x" $"#);
+test_eq!(string_literal_in_code_mode, r#"#raw("   foo   ");"#);
 test_eq!(
     line_wrap_off,
     "a very very very very very very very very very very very very very long line",


### PR DESCRIPTION
fixes #116.

Maybe some tests should be added (I didn't know where to add it).
