### PR TITLE
Fix #137 : Formatting alignments in math panics.

### DIFF
--- a/lib/src/tests/math.rs
+++ b/lib/src/tests/math.rs
@@ -69,3 +69,26 @@ $"#
 );
 
 make_test!(mathblock8, r#"$#xx(a,b) &= 1 \ #xx(a,b) &= 1 \ &= 2 \ $"#);
+
+make_test!(
+    mathblock9,
+    r#"
+$
+  a
+  &= b\
+  &= c & d\
+  &= &e & f\
+  &= && & g
+$"#
+);
+
+make_test!(
+    mathblock10,
+    r#"
+$
+  a&=b & c & d & e\
+  &= "a really long string" & pi \
+  &= a & #xx & d & e \
+  &= "an even longer string!!" & y
+$"#
+);

--- a/lib/src/tests/snapshots/typstfmt_lib__tests__math__mathblock10__snapshot.snap
+++ b/lib/src/tests/snapshots/typstfmt_lib__tests__math__mathblock10__snapshot.snap
@@ -1,0 +1,6 @@
+---
+source: lib/src/tests/math.rs
+description: "INPUT\n===\n\"\\n$\\n  a&=b & c & d & e\\\\\\n  &= \\\"a really long string\\\" & pi \\\\\\n  &= a & #xx & d & e \\\\\\n  &= \\\"an even longer string!!\\\" & y\\n$\"\n===\n\n$\n  a&=b & c & d & e\\\n  &= \"a really long string\" & pi \\\n  &= a & #xx & d & e \\\n  &= \"an even longer string!!\" & y\n$\n===\nFORMATTED\n===\n\n$\n  a&=b                          & c   & d & e\\\n   &= \"a really long string\"    & pi \\\n   &= a                         & #xx & d & e \\\n   &= \"an even longer string!!\" & y\n$"
+expression: formatted
+---
+"\n$\n  a&=b                          & c   & d & e\\\n   &= \"a really long string\"    & pi \\\n   &= a                         & #xx & d & e \\\n   &= \"an even longer string!!\" & y\n$"

--- a/lib/src/tests/snapshots/typstfmt_lib__tests__math__mathblock9__snapshot.snap
+++ b/lib/src/tests/snapshots/typstfmt_lib__tests__math__mathblock9__snapshot.snap
@@ -1,0 +1,6 @@
+---
+source: lib/src/tests/math.rs
+description: "INPUT\n===\n\"\\n$\\n  a\\n  &= b\\\\\\n  &= c & d\\\\\\n  &= &e & f\\\\\\n  &= && & g\\n$\"\n===\n\n$\n  a\n  &= b\\\n  &= c & d\\\n  &= &e & f\\\n  &= && & g\n$\n===\nFORMATTED\n===\n\n$\n  a\n    &= b\\\n    &= c & d\\\n    &=   &e & f\\\n    &=   &  & & g\n$"
+expression: formatted
+---
+"\n$\n  a\n    &= b\\\n    &= c & d\\\n    &=   &e & f\\\n    &=   &  & & g\n$"


### PR DESCRIPTION
The problem was that the code assumed that each line had the same number of alignment points. When this is not the case, formatting one alignment point can cause a shift in other alignment points beyond the previously calculated position. The code now precalculates the shifts that happen due to aligning the alignment points.

This also adds two new tests which ensure that the alignment behaves as expected, even in weird edge cases.