### PR TITLE
change the commit hook strategy

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,8 +1,0 @@
----
-- id: typstfmt
-  name: typstfmt
-  description: >
-    format typst
-  entry: typstfmt
-  language: rust
-  files: \.typ$

--- a/README.md
+++ b/README.md
@@ -54,33 +54,23 @@ cargo install --git https://github.com/astrale-sharp/typstfmt.git
 
 ## Setting up a pre-commit hook
 
-You can set up a git [hook](https://pre-commit.com).
-
-Every `git commit`, will then format automatically every .typ file before
-committing.
-
-run:
+Optionally, you can setup a git hook to format your files at each commit:
 
 ```sh
-echo "\
-repos:
-  - repo: https://github.com/astrale-sharp/typstfmt
-    rev: 1c414de
-    hooks:
-      - id: typstfmt
-" > .pre-commit-config.yaml
+echo "set -e
+
+for f in \$(git ls-files --full-name -- '*.typ') ; do
+    typstfmt --check \$f --verbose
+done" > .git/hooks/pre-commit
+
+chmod +x .git/hooks/pre-commit
 ```
 
-to add a configured `.pre-commit-config.yaml` file.
+Now if you try to commit unformatted files, they will be caught and the commit will fail, telling you which file should be fixed.
 
-You should then run:
-
-```sh
-pre-commit install
-pre-commit autoupdate
-```
-
-And your set up is done!
+> Notes:
+> - You should probably avoid doing this at the moment, as typstfmt is not quite stable yet
+> - Be careful if you have another commit hook setup, as the command above will replace it entirely!
 
 # Contributing
 


### PR DESCRIPTION
This changes the pre-commit thing to a 'raw' version, no dependency required 😉. Please test this and tell me what you think, I think this is more or less the same as the previous version (except it's now a pure shell script).

Should fix #146.
