### PR TITLE
Fix math alignement ('&') when math contains non-ascii characters

### DIFF
--- a/src/math.rs
+++ b/src/math.rs
@@ -82,7 +82,7 @@ pub(crate) fn format_math(parent: &LinkedNode, children: &[String], ctx: &mut Ct
                     &mut res,
                 );
                 ctx.push_raw_in(s, &mut res);
-                position = align_columns[index] + s.len();
+                position = align_columns[index] + s.chars().count();
                 index += 1;
 
                 first_align = false;
@@ -97,7 +97,7 @@ pub(crate) fn format_math(parent: &LinkedNode, children: &[String], ctx: &mut Ct
                 ctx.push_raw_in(" ", &mut res);
             }
             _ => {
-                position += s.len();
+                position += s.chars().count();
                 ctx.push_raw_in(s, &mut res)
             }
         }
@@ -142,7 +142,7 @@ fn retrieve_align_columns(parent: &LinkedNode, children: &[String]) -> Vec<usize
                 position += 1;
             }
             _ => {
-                position += s.len();
+                position += s.chars().count();
             }
         }
     }

--- a/src/tests/math.rs
+++ b/src/tests/math.rs
@@ -92,3 +92,14 @@ $
   &= "an even longer string!!" & y
 $"#
 );
+
+make_test!(
+    unicode_math_alignment,
+    r#"
+$
+ α   & := β & ("text") \
+ α &    := b & ("text") \
+ a & ≠  β & ("text") \
+ a    & ≠  b &   ("text")
+$"#
+);

--- a/src/tests/snapshots/typstfmt__tests__math__unicode_math_alignment__snapshot.snap
+++ b/src/tests/snapshots/typstfmt__tests__math__unicode_math_alignment__snapshot.snap
@@ -1,0 +1,6 @@
+---
+source: src/tests/math.rs
+description: "INPUT\n===\n\"\\n$\\n α   & := β & (\\\"text\\\") \\\\\\n α &    := b & (\\\"text\\\") \\\\\\n a & ≠  β & (\\\"text\\\") \\\\\\n a    & ≠  b &   (\\\"text\\\")\\n$\"\n===\n\n$\n α   & := β & (\"text\") \\\n α &    := b & (\"text\") \\\n a & ≠  β & (\"text\") \\\n a    & ≠  b &   (\"text\")\n$\n===\nFORMATTED\n===\n\n$\n  α & := β & (\"text\") \\\n  α & := b & (\"text\") \\\n  a & ≠ β  & (\"text\") \\\n  a & ≠ b  & (\"text\")\n$"
+expression: formatted
+---
+"\n$\n  α & := β & (\"text\") \\\n  α & := b & (\"text\") \\\n  a & ≠ β  & (\"text\") \\\n  a & ≠ b  & (\"text\")\n$"


### PR DESCRIPTION
So I noticed that alignment formatting in math mode sometimes gives strange result:
```typst
$
x & = y \
α & β
$
// becomes
$
  x  & = y \
  α & = β
$
```
It was due to usages of `s.len()`, which I replaced with `s.chars().count()`.

Note that this does not attempt to handle unicode characters with weird widths, like
```
ＡＢＣ
ABC
```
(Yes, it's real: those are `U+FF21`, `U+FF22` and `U+FF23`, known as "fullwidth" ascii characters)