### PR TITLE
fix show_all.sh after workspace improvement change

### DIFF
--- a/show_all.sh
+++ b/show_all.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-for snapshot in lib/src/tests/snapshots/*; do
+for snapshot in src/tests/snapshots/*; do
   cargo insta show "$snapshot"
   echo 'Press enter to continue'
   read -r _


### PR DESCRIPTION
While investigating #167, I was using `show_all.sh` and realized that it had been broken by 46a9a23b6b3306f8919bc2d886bccb4c97c9e387, so this fixes it to work with the new folder layout.